### PR TITLE
[fix]お気に入り登録処理をsession_idベースに修正

### DIFF
--- a/app/api/endpoints/favorite.py
+++ b/app/api/endpoints/favorite.py
@@ -1,15 +1,15 @@
 from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.orm import Session
-from app.models import Favorite, message
+from app.models import Favorite, Session as DBSession
 from app.schemas.favorite import FavoriteCreate, FavoriteResponse
 from app.core.database import get_db
 
 @router.post("/favorites")
 async def create_favorite(favorite_data: FavoriteCreate, db: Session = Depends(get_db)):
-    message = db.query(Message).filter(Message.id == favorite_data.message_id).first()
-    if not message:
+    session = db.query(DBSession).filter(DBSession.id == favorite_data.session_id).first()
+    if not session:
         raise HTTPException(status_code=404, detail="お気に入り登録が見つかりません。")
-    favorite = Favorite(message_id=favorite_data.message_id, user_id=favorite_data.user_id)
+    favorite = Favorite(session_id=favorite_data.session_id, user_id=favorite_data.user_id)
     db.add(favorite)
     db.commit()
     return favorite


### PR DESCRIPTION
## 目的
- セッション単位でお気に入り登録処理を行うため

## 実装の概要/やったこと
- app/api/endpoints/favorite.pyをmessage_idベースからsession_idベースに修正

- このプルリクで何をしたのか？

## 保留/やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
